### PR TITLE
feat: implement add contract dialog with settings management

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -28,6 +28,9 @@ const breadcrumbTitles: { [key: string]: string } = {
 	metrics: 'Metrics',
 	alerts: 'Alerts',
 	settings: 'Settings',
+	contracts: 'Contracts',
+	account: 'Account',
+	general: 'General',
 };
 
 export default function DashboardLayout({

--- a/app/dashboard/settings/account/page.tsx
+++ b/app/dashboard/settings/account/page.tsx
@@ -1,8 +1,10 @@
 export default function AccountSettingsPage() {
 	return (
-		<div className='rounded-xl bg-muted/50 p-4'>
-			<h3 className='text-lg font-medium'>Welcome to Account Settings</h3>
-			<p className='text-muted-foreground'>
+		<div className='rounded-lg bg-muted/50 p-3'>
+			<h3 className='text-base font-medium'>
+				Welcome to Account Settings
+			</h3>
+			<p className='text-sm text-muted-foreground'>
 				Select a category from the sidebar to manage your settings.
 			</p>
 		</div>

--- a/app/dashboard/settings/account/page.tsx
+++ b/app/dashboard/settings/account/page.tsx
@@ -1,0 +1,10 @@
+export default function AccountSettingsPage() {
+	return (
+		<div className='rounded-xl bg-muted/50 p-4'>
+			<h3 className='text-lg font-medium'>Welcome to Account Settings</h3>
+			<p className='text-muted-foreground'>
+				Select a category from the sidebar to manage your settings.
+			</p>
+		</div>
+	);
+}

--- a/app/dashboard/settings/contracts/page.tsx
+++ b/app/dashboard/settings/contracts/page.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import * as React from 'react';
+import { Plus } from 'lucide-react';
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { AddContractDialog } from '@/components/add-contract-dialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+// Using the same sample contracts from contract-switcher for now
+const sampleContracts = [
+	{
+		name: 'Token Contract',
+		contractId: 'CACT...X4WY',
+		network: 'mainnet',
+	},
+	{
+		name: 'Liquidity Pool',
+		contractId: 'CBXC...L9MN',
+		network: 'mainnet',
+	},
+	{
+		name: 'NFT Marketplace',
+		contractId: 'CDEF...K3PQ',
+		network: 'testnet',
+	},
+];
+
+export default function ContractsSettingsPage() {
+	const [contracts, setContracts] = React.useState(sampleContracts);
+
+	const handleDeleteContract = (contract: (typeof sampleContracts)[0]) => {
+		setContracts((prev) =>
+			prev.filter((c) => c.contractId !== contract.contractId)
+		);
+	};
+
+	return (
+		<div className='rounded-md border'>
+			<div className='flex items-center justify-between p-4'>
+				<div>
+					<h3 className='text-lg font-medium'>Contract List</h3>
+					<p className='text-sm text-muted-foreground'>
+						Manage your monitored Soroban contracts.
+					</p>
+				</div>
+				<AddContractDialog
+					trigger={
+						<Button>
+							<Plus className='mr-2 h-4 w-4' />
+							Add Contract
+						</Button>
+					}
+				/>
+			</div>
+
+			<Table>
+				<TableHeader>
+					<TableRow>
+						<TableHead>Name</TableHead>
+						<TableHead>Contract ID</TableHead>
+						<TableHead>Network</TableHead>
+						<TableHead className='w-[100px]'>Actions</TableHead>
+					</TableRow>
+				</TableHeader>
+				<TableBody>
+					{contracts.map((contract) => (
+						<TableRow key={contract.contractId}>
+							<TableCell className='font-medium'>
+								{contract.name}
+							</TableCell>
+							<TableCell className='font-mono'>
+								{contract.contractId}
+							</TableCell>
+							<TableCell>
+								<span
+									className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
+										contract.network === 'mainnet'
+											? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+											: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+									}`}
+								>
+									{contract.network}
+								</span>
+							</TableCell>
+							<TableCell>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											variant='ghost'
+											className='h-8 w-8 p-0'
+										>
+											<span className='sr-only'>
+												Open menu
+											</span>
+											<svg
+												className='h-4 w-4'
+												xmlns='http://www.w3.org/2000/svg'
+												viewBox='0 0 24 24'
+												fill='none'
+												stroke='currentColor'
+												strokeWidth='2'
+												strokeLinecap='round'
+												strokeLinejoin='round'
+											>
+												<circle
+													cx='12'
+													cy='12'
+													r='1'
+												/>
+												<circle
+													cx='12'
+													cy='5'
+													r='1'
+												/>
+												<circle
+													cx='12'
+													cy='19'
+													r='1'
+												/>
+											</svg>
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align='end'>
+										<DropdownMenuLabel>
+											Actions
+										</DropdownMenuLabel>
+										<DropdownMenuItem
+											onClick={() =>
+												console.log('Edit', contract)
+											}
+										>
+											Edit Contract
+										</DropdownMenuItem>
+										<DropdownMenuSeparator />
+										<AlertDialog>
+											<AlertDialogTrigger asChild>
+												<DropdownMenuItem
+													className='text-destructive focus:bg-destructive focus:text-destructive-foreground'
+													onSelect={(e) =>
+														e.preventDefault()
+													}
+												>
+													Delete Contract
+												</DropdownMenuItem>
+											</AlertDialogTrigger>
+											<AlertDialogContent>
+												<AlertDialogHeader>
+													<AlertDialogTitle>
+														Delete Contract
+													</AlertDialogTitle>
+													<AlertDialogDescription>
+														Are you sure you want to
+														delete{' '}
+														<span className='font-medium'>
+															{contract.name}
+														</span>
+														? This action cannot be
+														undone.
+													</AlertDialogDescription>
+												</AlertDialogHeader>
+												<AlertDialogFooter>
+													<AlertDialogCancel>
+														Cancel
+													</AlertDialogCancel>
+													<AlertDialogAction
+														onClick={() =>
+															handleDeleteContract(
+																contract
+															)
+														}
+														className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+													>
+														Delete
+													</AlertDialogAction>
+												</AlertDialogFooter>
+											</AlertDialogContent>
+										</AlertDialog>
+									</DropdownMenuContent>
+								</DropdownMenu>
+							</TableCell>
+						</TableRow>
+					))}
+				</TableBody>
+			</Table>
+		</div>
+	);
+}

--- a/app/dashboard/settings/contracts/page.tsx
+++ b/app/dashboard/settings/contracts/page.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import { Plus } from 'lucide-react';
-
 import {
 	Table,
 	TableBody,
@@ -32,6 +31,7 @@ import {
 	AlertDialogTitle,
 	AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { Skeleton } from '@/components/ui/skeleton';
 
 // Using the same sample contracts from contract-switcher for now
 const sampleContracts = [
@@ -54,6 +54,13 @@ const sampleContracts = [
 
 export default function ContractsSettingsPage() {
 	const [contracts, setContracts] = React.useState(sampleContracts);
+	const [isLoading, setIsLoading] = React.useState(true);
+
+	React.useEffect(() => {
+		// Simulate loading state
+		const timer = setTimeout(() => setIsLoading(false), 1000);
+		return () => clearTimeout(timer);
+	}, []);
 
 	const handleDeleteContract = (contract: (typeof sampleContracts)[0]) => {
 		setContracts((prev) =>
@@ -62,17 +69,19 @@ export default function ContractsSettingsPage() {
 	};
 
 	return (
-		<div className='rounded-md border'>
-			<div className='flex items-center justify-between p-4'>
+		<div className='space-y-3'>
+			<div className='flex items-center justify-between'>
 				<div>
-					<h3 className='text-lg font-medium'>Contract List</h3>
+					<h3 className='text-base font-medium'>
+						Contract Management
+					</h3>
 					<p className='text-sm text-muted-foreground'>
-						Manage your monitored Soroban contracts.
+						Manage your Soroban smart contracts
 					</p>
 				</div>
 				<AddContractDialog
 					trigger={
-						<Button>
+						<Button size='sm'>
 							<Plus className='mr-2 h-4 w-4' />
 							Add Contract
 						</Button>
@@ -80,135 +89,176 @@ export default function ContractsSettingsPage() {
 				/>
 			</div>
 
-			<Table>
-				<TableHeader>
-					<TableRow>
-						<TableHead>Name</TableHead>
-						<TableHead>Contract ID</TableHead>
-						<TableHead>Network</TableHead>
-						<TableHead className='w-[100px]'>Actions</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody>
-					{contracts.map((contract) => (
-						<TableRow key={contract.contractId}>
-							<TableCell className='font-medium'>
-								{contract.name}
-							</TableCell>
-							<TableCell className='font-mono'>
-								{contract.contractId}
-							</TableCell>
-							<TableCell>
-								<span
-									className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
-										contract.network === 'mainnet'
-											? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-											: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-									}`}
+			<div className='rounded-md border'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className='w-[200px]'>Name</TableHead>
+							<TableHead>Contract ID</TableHead>
+							<TableHead className='w-[100px]'>Network</TableHead>
+							<TableHead className='w-[100px] text-right'>
+								Actions
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							Array.from({ length: 3 }).map((_, index) => (
+								<TableRow key={index}>
+									<TableCell>
+										<Skeleton className='h-5 w-[120px]' />
+									</TableCell>
+									<TableCell>
+										<Skeleton className='h-5 w-[180px]' />
+									</TableCell>
+									<TableCell>
+										<Skeleton className='h-5 w-[80px]' />
+									</TableCell>
+									<TableCell className='text-right'>
+										<Skeleton className='ml-auto h-8 w-8' />
+									</TableCell>
+								</TableRow>
+							))
+						) : contracts.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={4}
+									className='h-[72px] text-center'
 								>
-									{contract.network}
-								</span>
-							</TableCell>
-							<TableCell>
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild>
-										<Button
-											variant='ghost'
-											className='h-8 w-8 p-0'
+									<p className='text-sm text-muted-foreground'>
+										No contracts added yet. Add your first
+										contract to get started.
+									</p>
+								</TableCell>
+							</TableRow>
+						) : (
+							contracts.map((contract) => (
+								<TableRow key={contract.contractId}>
+									<TableCell className='font-medium'>
+										{contract.name}
+									</TableCell>
+									<TableCell className='font-mono text-sm'>
+										{contract.contractId}
+									</TableCell>
+									<TableCell>
+										<span
+											className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${
+												contract.network === 'mainnet'
+													? 'bg-green-50 text-green-700 ring-green-600/20 dark:bg-green-900/30 dark:text-green-400 dark:ring-green-500/20'
+													: 'bg-yellow-50 text-yellow-700 ring-yellow-600/20 dark:bg-yellow-900/30 dark:text-yellow-400 dark:ring-yellow-500/20'
+											}`}
 										>
-											<span className='sr-only'>
-												Open menu
-											</span>
-											<svg
-												className='h-4 w-4'
-												xmlns='http://www.w3.org/2000/svg'
-												viewBox='0 0 24 24'
-												fill='none'
-												stroke='currentColor'
-												strokeWidth='2'
-												strokeLinecap='round'
-												strokeLinejoin='round'
-											>
-												<circle
-													cx='12'
-													cy='12'
-													r='1'
-												/>
-												<circle
-													cx='12'
-													cy='5'
-													r='1'
-												/>
-												<circle
-													cx='12'
-													cy='19'
-													r='1'
-												/>
-											</svg>
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent align='end'>
-										<DropdownMenuLabel>
-											Actions
-										</DropdownMenuLabel>
-										<DropdownMenuItem
-											onClick={() =>
-												console.log('Edit', contract)
-											}
-										>
-											Edit Contract
-										</DropdownMenuItem>
-										<DropdownMenuSeparator />
-										<AlertDialog>
-											<AlertDialogTrigger asChild>
+											{contract.network}
+										</span>
+									</TableCell>
+									<TableCell className='text-right'>
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button
+													variant='ghost'
+													className='h-8 w-8 p-0'
+												>
+													<span className='sr-only'>
+														Open menu
+													</span>
+													<svg
+														className='h-4 w-4'
+														xmlns='http://www.w3.org/2000/svg'
+														viewBox='0 0 24 24'
+														fill='none'
+														stroke='currentColor'
+														strokeWidth='2'
+														strokeLinecap='round'
+														strokeLinejoin='round'
+													>
+														<circle
+															cx='12'
+															cy='12'
+															r='1'
+														/>
+														<circle
+															cx='12'
+															cy='5'
+															r='1'
+														/>
+														<circle
+															cx='12'
+															cy='19'
+															r='1'
+														/>
+													</svg>
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align='end'>
+												<DropdownMenuLabel>
+													Actions
+												</DropdownMenuLabel>
 												<DropdownMenuItem
-													className='text-destructive focus:bg-destructive focus:text-destructive-foreground'
-													onSelect={(e) =>
-														e.preventDefault()
+													onClick={() =>
+														console.log(
+															'Edit',
+															contract
+														)
 													}
 												>
-													Delete Contract
+													Edit Contract
 												</DropdownMenuItem>
-											</AlertDialogTrigger>
-											<AlertDialogContent>
-												<AlertDialogHeader>
-													<AlertDialogTitle>
-														Delete Contract
-													</AlertDialogTitle>
-													<AlertDialogDescription>
-														Are you sure you want to
-														delete{' '}
-														<span className='font-medium'>
-															{contract.name}
-														</span>
-														? This action cannot be
-														undone.
-													</AlertDialogDescription>
-												</AlertDialogHeader>
-												<AlertDialogFooter>
-													<AlertDialogCancel>
-														Cancel
-													</AlertDialogCancel>
-													<AlertDialogAction
-														onClick={() =>
-															handleDeleteContract(
-																contract
-															)
-														}
-														className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
-													>
-														Delete
-													</AlertDialogAction>
-												</AlertDialogFooter>
-											</AlertDialogContent>
-										</AlertDialog>
-									</DropdownMenuContent>
-								</DropdownMenu>
-							</TableCell>
-						</TableRow>
-					))}
-				</TableBody>
-			</Table>
+												<DropdownMenuSeparator />
+												<AlertDialog>
+													<AlertDialogTrigger asChild>
+														<DropdownMenuItem
+															className='text-destructive focus:bg-destructive focus:text-destructive-foreground'
+															onSelect={(e) =>
+																e.preventDefault()
+															}
+														>
+															Delete Contract
+														</DropdownMenuItem>
+													</AlertDialogTrigger>
+													<AlertDialogContent>
+														<AlertDialogHeader>
+															<AlertDialogTitle>
+																Delete Contract
+															</AlertDialogTitle>
+															<AlertDialogDescription>
+																Are you sure you
+																want to delete{' '}
+																<span className='font-medium'>
+																	{
+																		contract.name
+																	}
+																</span>
+																? This action
+																cannot be
+																undone.
+															</AlertDialogDescription>
+														</AlertDialogHeader>
+														<AlertDialogFooter>
+															<AlertDialogCancel>
+																Cancel
+															</AlertDialogCancel>
+															<AlertDialogAction
+																onClick={() =>
+																	handleDeleteContract(
+																		contract
+																	)
+																}
+																className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
+															>
+																Delete
+															</AlertDialogAction>
+														</AlertDialogFooter>
+													</AlertDialogContent>
+												</AlertDialog>
+											</DropdownMenuContent>
+										</DropdownMenu>
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
 		</div>
 	);
 }

--- a/app/dashboard/settings/general/page.tsx
+++ b/app/dashboard/settings/general/page.tsx
@@ -1,0 +1,10 @@
+export default function GeneralSettingsPage() {
+	return (
+		<div className='rounded-xl bg-muted/50 p-4'>
+			<h3 className='text-lg font-medium'>Welcome to General Settings</h3>
+			<p className='text-muted-foreground'>
+				Select a category from the sidebar to manage your settings.
+			</p>
+		</div>
+	);
+}

--- a/app/dashboard/settings/general/page.tsx
+++ b/app/dashboard/settings/general/page.tsx
@@ -1,8 +1,10 @@
 export default function GeneralSettingsPage() {
 	return (
-		<div className='rounded-xl bg-muted/50 p-4'>
-			<h3 className='text-lg font-medium'>Welcome to General Settings</h3>
-			<p className='text-muted-foreground'>
+		<div className='rounded-lg bg-muted/50 p-3'>
+			<h3 className='text-base font-medium'>
+				Welcome to General Settings
+			</h3>
+			<p className='text-sm text-muted-foreground'>
 				Select a category from the sidebar to manage your settings.
 			</p>
 		</div>

--- a/app/dashboard/settings/layout.tsx
+++ b/app/dashboard/settings/layout.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Settings | Soroban Monitor',
+	description:
+		'Settings and configuration for Soroban smart contract monitoring',
+};
+
+interface SettingsLayoutProps {
+	children: React.ReactNode;
+}
+
+export default function SettingsLayout({ children }: SettingsLayoutProps) {
+	return <div className='flex flex-1 flex-col gap-4 p-4'>{children}</div>;
+}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,17 +1,5 @@
-import { Metadata } from 'next';
-
-export const metadata: Metadata = {
-	title: 'Settings | Soroban Monitor',
-	description:
-		'Settings and configuration for Soroban smart contract monitoring',
-};
+import { redirect } from 'next/navigation';
 
 export default function SettingsPage() {
-	return (
-		<div className='flex flex-1 flex-col gap-4 p-4'>
-			<div className='rounded-xl bg-muted/50 p-4'>
-				Settings Configuration Coming Soon
-			</div>
-		</div>
-	);
+	redirect('/dashboard/settings/general');
 }

--- a/components/add-contract-dialog.tsx
+++ b/components/add-contract-dialog.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 
 const formSchema = z.object({
 	contractId: z
@@ -35,6 +36,9 @@ const formSchema = z.object({
 		.string()
 		.min(1, 'Name is required')
 		.max(50, 'Name must be less than 50 characters'),
+	network: z.enum(['mainnet', 'testnet'], {
+		required_error: 'Please select a network',
+	}),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -54,6 +58,7 @@ export function AddContractDialog({
 		defaultValues: {
 			contractId: '',
 			friendlyName: '',
+			network: 'mainnet',
 		},
 	});
 
@@ -145,6 +150,44 @@ export function AddContractDialog({
 									</FormControl>
 									<FormDescription>
 										A memorable name for this contract
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name='network'
+							render={({ field }) => (
+								<FormItem className='space-y-3'>
+									<FormLabel>Network</FormLabel>
+									<FormControl>
+										<RadioGroup
+											onValueChange={field.onChange}
+											defaultValue={field.value}
+											className='flex space-x-4'
+										>
+											<FormItem className='flex items-center space-x-2 space-y-0'>
+												<FormControl>
+													<RadioGroupItem value='mainnet' />
+												</FormControl>
+												<FormLabel className='font-normal'>
+													Mainnet
+												</FormLabel>
+											</FormItem>
+											<FormItem className='flex items-center space-x-2 space-y-0'>
+												<FormControl>
+													<RadioGroupItem value='testnet' />
+												</FormControl>
+												<FormLabel className='font-normal'>
+													Testnet
+												</FormLabel>
+											</FormItem>
+										</RadioGroup>
+									</FormControl>
+									<FormDescription>
+										Select the network this contract is
+										deployed on
 									</FormDescription>
 									<FormMessage />
 								</FormItem>

--- a/components/add-contract-dialog.tsx
+++ b/components/add-contract-dialog.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+const formSchema = z.object({
+	contractId: z
+		.string()
+		.min(1, 'Contract ID is required')
+		.regex(/^C[A-Z0-9]{55}$/, 'Invalid Soroban Contract ID format'),
+	friendlyName: z
+		.string()
+		.min(1, 'Name is required')
+		.max(50, 'Name must be less than 50 characters'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface AddContractDialogProps {
+	trigger?: React.ReactNode;
+	onOpenChange?: (open: boolean) => void;
+}
+
+export function AddContractDialog({
+	trigger,
+	onOpenChange,
+}: AddContractDialogProps) {
+	const [open, setOpen] = React.useState(false);
+	const form = useForm<FormValues>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			contractId: '',
+			friendlyName: '',
+		},
+	});
+
+	const handleOpenChange = (newOpen: boolean) => {
+		setOpen(newOpen);
+		onOpenChange?.(newOpen);
+	};
+
+	function onSubmit(data: FormValues) {
+		// For MVP, just log the data
+		console.log('Contract Data:', data);
+		handleOpenChange(false);
+		form.reset();
+	}
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={handleOpenChange}
+		>
+			<DialogTrigger asChild>
+				{trigger || <Button>Add Contract</Button>}
+			</DialogTrigger>
+			<DialogContent className='sm:max-w-[425px]'>
+				<DialogHeader>
+					<DialogTitle>Add Contract</DialogTitle>
+					<DialogDescription>
+						Enter your Soroban contract details below to start
+						monitoring.
+					</DialogDescription>
+				</DialogHeader>
+				<Form {...form}>
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className='space-y-4'
+					>
+						<FormField
+							control={form.control}
+							name='contractId'
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Contract ID</FormLabel>
+									<FormControl>
+										<Input
+											placeholder='C...'
+											{...field}
+											className='font-mono'
+										/>
+									</FormControl>
+									<FormDescription>
+										Your Soroban contract ID starting with C
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name='friendlyName'
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Friendly Name</FormLabel>
+									<FormControl>
+										<Input
+											placeholder='My Token Contract'
+											{...field}
+										/>
+									</FormControl>
+									<FormDescription>
+										A memorable name for this contract
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<div className='flex justify-end space-x-4 pt-4'>
+							<Button
+								type='button'
+								variant='outline'
+								onClick={() => setOpen(false)}
+							>
+								Cancel
+							</Button>
+							<Button type='submit'>Add Contract</Button>
+						</div>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/add-contract-dialog.tsx
+++ b/components/add-contract-dialog.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useHotkeys } from 'react-hotkeys-hook';
 
 import {
 	Dialog,
@@ -61,6 +62,20 @@ export function AddContractDialog({
 		onOpenChange?.(newOpen);
 	};
 
+	// Add hotkey to open dialog
+	useHotkeys(
+		'mod+k',
+		(e) => {
+			e.preventDefault();
+			handleOpenChange(true);
+		},
+		{
+			enableOnFormTags: true,
+			preventDefault: true,
+		},
+		[handleOpenChange]
+	);
+
 	function onSubmit(data: FormValues) {
 		// For MVP, just log the data
 		console.log('Contract Data:', data);
@@ -74,7 +89,14 @@ export function AddContractDialog({
 			onOpenChange={handleOpenChange}
 		>
 			<DialogTrigger asChild>
-				{trigger || <Button>Add Contract</Button>}
+				{trigger || (
+					<Button>
+						Add Contract
+						<kbd className='pointer-events-none ml-2 hidden select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:inline-flex'>
+							<span className='text-xs'>⌘</span>K
+						</kbd>
+					</Button>
+				)}
 			</DialogTrigger>
 			<DialogContent className='sm:max-w-[425px]'>
 				<DialogHeader>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -64,6 +64,20 @@ const data = {
 			icon: Settings2,
 			shortcut: '⌘⇧S',
 			hotkey: 'mod+shift+s',
+			items: [
+				{
+					title: 'General',
+					url: '/dashboard/settings/general',
+				},
+				{
+					title: 'Contracts',
+					url: '/dashboard/settings/contracts',
+				},
+				{
+					title: 'Account',
+					url: '/dashboard/settings/account',
+				},
+			],
 		},
 	],
 };

--- a/components/contract-switcher.tsx
+++ b/components/contract-switcher.tsx
@@ -42,10 +42,17 @@ const sampleContracts = [
 
 export function ContractSwitcher() {
 	const { isMobile } = useSidebar();
-	const [activeContract, setActiveContract] = React.useState(() => {
+	const [activeContract, setActiveContract] = React.useState(
+		sampleContracts[0]
+	);
+
+	// Load stored contract on client-side only
+	React.useEffect(() => {
 		const stored = localStorage.getItem('activeContract');
-		return stored ? JSON.parse(stored) : sampleContracts[0];
-	});
+		if (stored) {
+			setActiveContract(JSON.parse(stored));
+		}
+	}, []);
 
 	// Persist selected contract to localStorage
 	React.useEffect(() => {

--- a/components/contract-switcher.tsx
+++ b/components/contract-switcher.tsx
@@ -20,22 +20,23 @@ import {
 	useSidebar,
 } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
+import { AddContractDialog } from '@/components/add-contract-dialog';
 
 // Sample contract data - in real app, this would come from API/localStorage
 const sampleContracts = [
 	{
 		name: 'Token Contract',
-		contractId: 'GACT...X4WY',
+		contractId: 'CACT...X4WY',
 		network: 'mainnet',
 	},
 	{
 		name: 'Liquidity Pool',
-		contractId: 'GBXC...L9MN',
+		contractId: 'CBXC...L9MN',
 		network: 'mainnet',
 	},
 	{
 		name: 'NFT Marketplace',
-		contractId: 'GDEF...K3PQ',
+		contractId: 'CDEF...K3PQ',
 		network: 'testnet',
 	},
 ];
@@ -45,6 +46,7 @@ export function ContractSwitcher() {
 	const [activeContract, setActiveContract] = React.useState(
 		sampleContracts[0]
 	);
+	const [dropdownOpen, setDropdownOpen] = React.useState(false);
 
 	// Load stored contract on client-side only
 	React.useEffect(() => {
@@ -94,7 +96,10 @@ export function ContractSwitcher() {
 	return (
 		<SidebarMenu>
 			<SidebarMenuItem>
-				<DropdownMenu>
+				<DropdownMenu
+					open={dropdownOpen}
+					onOpenChange={setDropdownOpen}
+				>
 					<DropdownMenuTrigger asChild>
 						<SidebarMenuButton
 							size='lg'
@@ -168,14 +173,24 @@ export function ContractSwitcher() {
 							</DropdownMenuItem>
 						))}
 						<DropdownMenuSeparator />
-						<DropdownMenuItem className='gap-2 p-2'>
-							<div className='flex size-6 items-center justify-center rounded-md border bg-background'>
-								<Plus className='size-4' />
-							</div>
-							<div className='font-medium text-muted-foreground'>
-								Add Contract
-							</div>
-						</DropdownMenuItem>
+						<AddContractDialog
+							trigger={
+								<DropdownMenuItem
+									className='gap-2 p-2'
+									onSelect={(e) => e.preventDefault()}
+								>
+									<div className='flex size-6 items-center justify-center rounded-md border bg-background'>
+										<Plus className='size-4' />
+									</div>
+									<div className='font-medium text-muted-foreground'>
+										Add Contract
+									</div>
+								</DropdownMenuItem>
+							}
+							onOpenChange={(open) => {
+								if (!open) setDropdownOpen(false);
+							}}
+						/>
 					</DropdownMenuContent>
 				</DropdownMenu>
 			</SidebarMenuItem>

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -1,15 +1,23 @@
 'use client';
 
-import { type LucideIcon } from 'lucide-react';
+import { ChevronRight, type LucideIcon } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
 	SidebarGroup,
 	SidebarGroupLabel,
 	SidebarMenu,
 	SidebarMenuButton,
 	SidebarMenuItem,
+	SidebarMenuSub,
+	SidebarMenuSubButton,
+	SidebarMenuSubItem,
 } from '@/components/ui/sidebar';
 
 export function NavMain({
@@ -19,7 +27,10 @@ export function NavMain({
 		title: string;
 		url: string;
 		icon?: LucideIcon;
-		shortcut?: string;
+		items?: {
+			title: string;
+			url: string;
+		}[];
 	}[];
 }) {
 	const pathname = usePathname();
@@ -29,16 +40,95 @@ export function NavMain({
 			<SidebarGroupLabel>Platform</SidebarGroupLabel>
 			<SidebarMenu>
 				{items.map((item) => {
-					const isActive = pathname === item.url;
+					// For items with subitems, use Collapsible
+					if (item.items?.length) {
+						const isActive = pathname.startsWith(item.url);
+						return (
+							<Collapsible
+								key={item.title}
+								asChild
+								defaultOpen={isActive}
+								className='group/collapsible'
+							>
+								<SidebarMenuItem>
+									<CollapsibleTrigger asChild>
+										<SidebarMenuButton tooltip={item.title}>
+											{item.icon && <item.icon />}
+											<span>{item.title}</span>
+											<ChevronRight className='ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90' />
+										</SidebarMenuButton>
+									</CollapsibleTrigger>
+									<CollapsibleContent>
+										<SidebarMenuSub>
+											{item.items.map((subItem) => {
+												const isSubActive =
+													pathname.startsWith(
+														subItem.url
+													);
+												return (
+													<SidebarMenuSubItem
+														key={subItem.title}
+													>
+														<SidebarMenuSubButton
+															asChild
+															className={cn(
+																isSubActive &&
+																	'bg-sidebar-accent text-sidebar-accent-foreground'
+															)}
+														>
+															<a
+																href={
+																	subItem.url
+																}
+															>
+																<span>
+																	{
+																		subItem.title
+																	}
+																</span>
+															</a>
+														</SidebarMenuSubButton>
+													</SidebarMenuSubItem>
+												);
+											})}
+										</SidebarMenuSub>
+									</CollapsibleContent>
+								</SidebarMenuItem>
+							</Collapsible>
+						);
+					}
+
+					// For home page, only exact match
+					if (item.url === '/dashboard') {
+						const isActive = pathname === item.url;
+						return (
+							<SidebarMenuItem key={item.title}>
+								<SidebarMenuButton
+									asChild
+									tooltip={item.title}
+									className={cn(
+										isActive &&
+											'bg-sidebar-accent text-sidebar-accent-foreground'
+									)}
+								>
+									<a href={item.url}>
+										{item.icon && <item.icon />}
+										<span>{item.title}</span>
+									</a>
+								</SidebarMenuButton>
+							</SidebarMenuItem>
+						);
+					}
+
+					// For other pages without subitems
+					const isActive =
+						pathname === item.url ||
+						pathname.startsWith(`${item.url}/`);
 					return (
 						<SidebarMenuItem key={item.title}>
 							<SidebarMenuButton
 								asChild
-								tooltip={
-									item.shortcut
-										? `${item.title} (${item.shortcut})`
-										: item.title
-								}
+								tooltip={item.title}
 								className={cn(
 									isActive &&
 										'bg-sidebar-accent text-sidebar-accent-foreground'

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import * as React from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { Circle } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const RadioGroup = React.forwardRef<
+	React.ElementRef<typeof RadioGroupPrimitive.Root>,
+	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+	return (
+		<RadioGroupPrimitive.Root
+			className={cn('grid gap-2', className)}
+			{...props}
+			ref={ref}
+		/>
+	);
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+	React.ElementRef<typeof RadioGroupPrimitive.Item>,
+	React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+	return (
+		<RadioGroupPrimitive.Item
+			ref={ref}
+			className={cn(
+				'aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+				className
+			)}
+			{...props}
+		>
+			<RadioGroupPrimitive.Indicator className='flex items-center justify-center'>
+				<Circle className='h-3.5 w-3.5 fill-primary' />
+			</RadioGroupPrimitive.Indicator>
+		</RadioGroupPrimitive.Item>
+	);
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
+		"@hookform/resolvers": "^3.9.1",
 		"@radix-ui/react-avatar": "^1.1.2",
 		"@radix-ui/react-collapsible": "^1.1.2",
 		"@radix-ui/react-dialog": "^1.1.4",
 		"@radix-ui/react-dropdown-menu": "^2.1.4",
+		"@radix-ui/react-label": "^2.1.1",
 		"@radix-ui/react-popover": "^1.1.4",
 		"@radix-ui/react-separator": "^1.1.1",
 		"@radix-ui/react-slot": "^1.1.1",
@@ -27,9 +29,11 @@
 		"react": "^18",
 		"react-day-picker": "8.10.1",
 		"react-dom": "^18",
+		"react-hook-form": "^7.54.2",
 		"react-hotkeys-hook": "^4.6.1",
 		"tailwind-merge": "^2.6.0",
-		"tailwindcss-animate": "^1.0.7"
+		"tailwindcss-animate": "^1.0.7",
+		"zod": "^3.24.1"
 	},
 	"devDependencies": {
 		"@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^3.9.1",
+		"@radix-ui/react-alert-dialog": "^1.1.4",
 		"@radix-ui/react-avatar": "^1.1.2",
 		"@radix-ui/react-collapsible": "^1.1.2",
 		"@radix-ui/react-dialog": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@radix-ui/react-dropdown-menu": "^2.1.4",
 		"@radix-ui/react-label": "^2.1.1",
 		"@radix-ui/react-popover": "^1.1.4",
+		"@radix-ui/react-radio-group": "^1.2.2",
 		"@radix-ui/react-separator": "^1.1.1",
 		"@radix-ui/react-slot": "^1.1.1",
 		"@radix-ui/react-tooltip": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@radix-ui/react-popover':
     specifier: ^1.1.4
     version: 1.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+  '@radix-ui/react-radio-group':
+    specifier: ^1.2.2
+    version: 1.2.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
   '@radix-ui/react-separator':
     specifier: ^1.1.1
     version: 1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
@@ -814,6 +817,35 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-radio-group@1.2.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-E0MLLGfOP0l8P/NxgVzfXJ8w3Ch8cdO6UDzJfDChu4EJDy+/WdO5LqpdY8PYnCErkmZH3gZhDL1K7kQ41fAHuQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-roving-focus@1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==}
     peerDependencies:
@@ -950,6 +982,19 @@ packages:
 
   /@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.18)(react@18.3.1):
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.18
+      react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-use-previous@1.1.0(@types/react@18.3.18)(react@18.3.1):
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@hookform/resolvers':
+    specifier: ^3.9.1
+    version: 3.9.1(react-hook-form@7.54.2)
   '@radix-ui/react-avatar':
     specifier: ^1.1.2
     version: 1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
@@ -17,6 +20,9 @@ dependencies:
   '@radix-ui/react-dropdown-menu':
     specifier: ^2.1.4
     version: 2.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+  '@radix-ui/react-label':
+    specifier: ^2.1.1
+    version: 2.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
   '@radix-ui/react-popover':
     specifier: ^1.1.4
     version: 1.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
@@ -59,6 +65,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.3.1(react@18.3.1)
+  react-hook-form:
+    specifier: ^7.54.2
+    version: 7.54.2(react@18.3.1)
   react-hotkeys-hook:
     specifier: ^4.6.1
     version: 4.6.1(react-dom@18.3.1)(react@18.3.1)
@@ -68,6 +77,9 @@ dependencies:
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.17)
+  zod:
+    specifier: ^3.24.1
+    version: 3.24.1
 
 devDependencies:
   '@types/node':
@@ -164,6 +176,14 @@ packages:
 
   /@floating-ui/utils@0.2.8:
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+    dev: false
+
+  /@hookform/resolvers@3.9.1(react-hook-form@7.54.2):
+    resolution: {integrity: sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+    dependencies:
+      react-hook-form: 7.54.2(react@18.3.1)
     dev: false
 
   /@humanwhocodes/config-array@0.13.0:
@@ -610,6 +630,26 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       '@types/react': 18.3.18
       react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-label@2.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-UUw5E4e/2+4kFMH7+YxORXGWggtY6sM8WIwh5RZchhLuUg2H1hc98Py+pr8HMz6rdaYrK2t296ZEjYLOCO5uUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-menu@2.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
@@ -3025,6 +3065,15 @@ packages:
       scheduler: 0.23.2
     dev: false
 
+  /react-hook-form@7.54.2(react@18.3.1):
+    resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+    dependencies:
+      react: 18.3.1
+    dev: false
+
   /react-hotkeys-hook@4.6.1(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==}
     peerDependencies:
@@ -3759,3 +3808,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@hookform/resolvers':
     specifier: ^3.9.1
     version: 3.9.1(react-hook-form@7.54.2)
+  '@radix-ui/react-alert-dialog':
+    specifier: ^1.1.4
+    version: 1.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
   '@radix-ui/react-avatar':
     specifier: ^1.1.2
     version: 1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
@@ -369,6 +372,31 @@ packages:
 
   /@radix-ui/primitive@1.1.1:
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+    dev: false
+
+  /@radix-ui/react-alert-dialog@1.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-A6Kh23qZDLy3PSU4bh2UJZznOrUdHImIXqF8YtUa6CN73f8EOO9XlXSCd9IHyPvIquTaa/kwaSWzZTtUvgXVGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-arrow@1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):


### PR DESCRIPTION
Closes #6

Implements the Add Contract dialog with form validation, network selection, and keyboard shortcuts. Also adds a dedicated settings section for contract management with skeleton loading and New York theme styling.

### Changes Made
- ✨ Add contract dialog with form validation and network selection
- ⌨️ Global hotkey (⌘+K) to open add contract dialog
- 🏠 Settings pages with New York theme styling
- 🔄 Submenu navigation in sidebar for settings
- 💾 Form data logging for contract management (DB integration TBD)
- 🎨 Consistent New York theme styling across all settings pages
- 🔄 Skeleton loading for contracts table
- 💅 Enhanced network badges with ring styling
- ⚠️ Delete contract confirmation dialog

### Technical Details
- Used shadcn/ui Dialog and Form components for the add contract modal
- Implemented form validation using react-hook-form and zod
- Added network selection (Testnet/Mainnet) using RadioGroup
- Created settings submenu using Collapsible component
- Integrated with existing contract switcher component
- Added skeleton loading state for better UX
- Styled all components following New York theme guidelines
- Utilized Next.js app router for settings pages structure

### Testing
- [x] Add Contract dialog opens from contract switcher
- [x] Add Contract dialog opens with ⌘+K hotkey
- [x] Form validation works for Contract ID and Friendly Name
- [x] Network selection defaults to Mainnet
- [x] Form data is logged to console on submit
- [x] Settings submenu navigation works correctly
- [x] Settings pages show correct welcome messages
- [x] Breadcrumbs show correct navigation path
- [x] Skeleton loading appears on contracts page load
- [x] Delete contract confirmation works
- [x] Empty state shows when no contracts exist
- [x] Network badges show correct styling for Mainnet/Testnet

### Navigation Structure
dashboard/settings/
├── general/ # General settings page
├── contracts/ # Contracts management page
└── account/ # Account settings page


### Style Updates
- Followed New York theme specifications:
  - Smaller text sizes (`text-base` for headings)
  - Tighter spacing (`p-3` instead of `p-4`)
  - Refined border radius (`rounded-lg`)
  - Enhanced badge styling with rings
  - Consistent table styling with activity page