### PR TITLE
feat: implement performance page with charts and loading states

### DIFF
--- a/app/dashboard/performance/layout.tsx
+++ b/app/dashboard/performance/layout.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Performance | Soroban Monitor',
+	description:
+		'Performance monitoring and analytics for Soroban smart contracts',
+};
+
+export default function PerformanceLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return children;
+}

--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Suspense } from 'react';
+import { ChartSkeleton } from '@/components/charts/chart-skeleton';
 import { ContractCallsChart } from '@/components/charts/contract-calls-chart';
 import { ResourceUsageChart } from '@/components/charts/resource-usage-chart';
 import { ResponseTimeChart } from '@/components/charts/response-time-chart';
@@ -7,11 +9,21 @@ import { SuccessRateChart } from '@/components/charts/success-rate-chart';
 
 export default function PerformancePage() {
 	return (
-		<div className='grid gap-6 p-6 md:grid-cols-2'>
-			<ContractCallsChart />
-			<SuccessRateChart />
-			<ResponseTimeChart />
-			<ResourceUsageChart />
+		<div className='flex flex-1 flex-col p-4'>
+			<div className='grid gap-4 sm:grid-cols-2'>
+				<Suspense fallback={<ChartSkeleton />}>
+					<ContractCallsChart />
+				</Suspense>
+				<Suspense fallback={<ChartSkeleton />}>
+					<SuccessRateChart />
+				</Suspense>
+				<Suspense fallback={<ChartSkeleton />}>
+					<ResponseTimeChart />
+				</Suspense>
+				<Suspense fallback={<ChartSkeleton />}>
+					<ResourceUsageChart />
+				</Suspense>
+			</div>
 		</div>
 	);
 }

--- a/components/charts/chart-skeleton.tsx
+++ b/components/charts/chart-skeleton.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function ChartSkeleton() {
+	return (
+		<Card>
+			<CardHeader className='flex items-center gap-2 space-y-0 border-b py-5 sm:flex-row'>
+				<div className='grid flex-1 gap-2 text-center sm:text-left'>
+					<CardTitle>
+						<Skeleton className='h-5 w-32' />
+					</CardTitle>
+					<CardDescription>
+						<Skeleton className='h-4 w-48' />
+					</CardDescription>
+				</div>
+				<Skeleton className='h-10 w-[160px] rounded-lg sm:ml-auto' />
+			</CardHeader>
+			<CardContent className='px-2 pt-4 sm:px-6 sm:pt-6'>
+				<Skeleton className='aspect-auto h-[250px] w-full rounded-lg' />
+			</CardContent>
+			<CardFooter>
+				<div className='flex w-full flex-col items-start gap-2'>
+					<Skeleton className='h-5 w-40' />
+					<Skeleton className='h-4 w-32' />
+				</div>
+			</CardFooter>
+		</Card>
+	);
+}


### PR DESCRIPTION
This PR adds the performance monitoring page with responsive chart layouts and loading states.

### Changes include:

- Add metadata and layout configuration for the performance page
- Implement responsive grid layout with proper padding for charts
- Create skeleton loading states for a smoother loading experience
- Add chart container components with loading fallbacks using Suspense
- The changes follow the New York style guidelines and maintain consistent spacing across the dashboard.

### Testing:

- [x] Verify that all charts load correctly with skeleton states
- [x] Check responsive layout on different screen sizes
- [x] Confirm proper padding and spacing around charts
- [x] Verify metadata appears correctly in browser tab