### PR TITLE
feat: add recent events table to overview page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,6 +3,8 @@ import { MetricGrid } from '@/components/metrics/metric-grid';
 import { MetricCardSkeleton } from '@/components/metrics/metric-card-skeleton';
 import { Suspense } from 'react';
 import { Metrics } from './metrics';
+import { RecentEvents } from '@/components/recent-events/recent-events';
+import { RecentEventsSkeleton } from '@/components/recent-events/recent-events-skeleton';
 
 export const metadata: Metadata = {
 	title: 'Overview | Soroban Monitor',
@@ -31,6 +33,10 @@ export default function DashboardPage() {
 					<Metrics />
 				</Suspense>
 			</MetricGrid>
+
+			<Suspense fallback={<RecentEventsSkeleton />}>
+				<RecentEvents />
+			</Suspense>
 		</div>
 	);
 }

--- a/components/recent-events/columns.tsx
+++ b/components/recent-events/columns.tsx
@@ -1,0 +1,39 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { format } from 'date-fns';
+import { Badge } from '@/components/ui/badge';
+
+export interface Event {
+	id: string;
+	timestamp: Date;
+	function: string;
+	outcome: 'success' | 'failure';
+}
+
+export const columns: ColumnDef<Event>[] = [
+	{
+		accessorKey: 'timestamp',
+		header: 'Time',
+		cell: ({ row }) => {
+			return format(row.getValue('timestamp'), 'HH:mm:ss');
+		},
+	},
+	{
+		accessorKey: 'function',
+		header: 'Function',
+	},
+	{
+		accessorKey: 'outcome',
+		header: 'Status',
+		cell: ({ row }) => {
+			const outcome = row.getValue('outcome') as string;
+			return (
+				<Badge
+					variant={outcome === 'success' ? 'default' : 'destructive'}
+					className='capitalize'
+				>
+					{outcome}
+				</Badge>
+			);
+		},
+	},
+];

--- a/components/recent-events/recent-events-skeleton.tsx
+++ b/components/recent-events/recent-events-skeleton.tsx
@@ -1,0 +1,63 @@
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function RecentEventsSkeleton() {
+	return (
+		<div className='space-y-4'>
+			<div className='flex justify-between items-center'>
+				<h2 className='text-lg font-medium'>Recent Events</h2>
+				<Button
+					variant='outline'
+					disabled
+					className='gap-2'
+				>
+					View All
+					<ArrowRight className='h-4 w-4' />
+				</Button>
+			</div>
+			<div className='border rounded-md'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Date & Time</TableHead>
+							<TableHead>Function</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Gas Used</TableHead>
+							<TableHead>Execution Time</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{Array.from({ length: 5 }).map((_, i) => (
+							<TableRow key={i}>
+								<TableCell>
+									<Skeleton className='h-4 w-24' />
+								</TableCell>
+								<TableCell>
+									<Skeleton className='h-4 w-20' />
+								</TableCell>
+								<TableCell>
+									<Skeleton className='h-6 w-16 rounded-full' />
+								</TableCell>
+								<TableCell>
+									<Skeleton className='h-4 w-16' />
+								</TableCell>
+								<TableCell>
+									<Skeleton className='h-4 w-12' />
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+		</div>
+	);
+}

--- a/components/recent-events/recent-events.tsx
+++ b/components/recent-events/recent-events.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { format } from 'date-fns';
+import { cn } from '@/lib/utils';
+
+interface Event {
+	id: string;
+	timestamp: Date;
+	function: string;
+	outcome: 'success' | 'failure';
+	gasUsed: string;
+	executionTime: string;
+}
+
+// Sample data - replace with real data later
+const sampleEvents: Event[] = [
+	{
+		id: '1',
+		timestamp: new Date('2024-02-20T10:30:00'),
+		function: 'transfer',
+		outcome: 'success',
+		gasUsed: '21,000',
+		executionTime: '2.3s',
+	},
+	{
+		id: '2',
+		timestamp: new Date('2024-02-20T11:15:00'),
+		function: 'swap',
+		outcome: 'failure',
+		gasUsed: '45,000',
+		executionTime: '3.1s',
+	},
+	{
+		id: '3',
+		timestamp: new Date('2024-02-20T12:00:00'),
+		function: 'mint',
+		outcome: 'success',
+		gasUsed: '32,000',
+		executionTime: '1.8s',
+	},
+	{
+		id: '4',
+		timestamp: new Date('2024-02-20T12:30:00'),
+		function: 'transfer',
+		outcome: 'success',
+		gasUsed: '21,500',
+		executionTime: '2.1s',
+	},
+	{
+		id: '5',
+		timestamp: new Date('2024-02-20T13:00:00'),
+		function: 'burn',
+		outcome: 'failure',
+		gasUsed: '38,000',
+		executionTime: '2.8s',
+	},
+];
+
+export function RecentEvents() {
+	return (
+		<div className='space-y-4'>
+			<div className='flex justify-between items-center'>
+				<h2 className='text-lg font-medium'>Recent Events</h2>
+				<Button
+					variant='outline'
+					asChild
+				>
+					<Link
+						href='/dashboard/activity'
+						className='gap-2'
+					>
+						View All
+						<ArrowRight className='h-4 w-4' />
+					</Link>
+				</Button>
+			</div>
+			<div className='border rounded-md'>
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Date & Time</TableHead>
+							<TableHead>Function</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Gas Used</TableHead>
+							<TableHead>Execution Time</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{sampleEvents.map((event) => (
+							<TableRow key={event.id}>
+								<TableCell>
+									{format(event.timestamp, 'MMM d, HH:mm:ss')}
+								</TableCell>
+								<TableCell className='font-medium'>
+									{event.function}
+								</TableCell>
+								<TableCell>
+									<span
+										className={cn(
+											'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
+											event.outcome === 'success'
+												? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+												: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+										)}
+									>
+										{event.outcome}
+									</span>
+								</TableCell>
+								<TableCell className='text-muted-foreground'>
+									{event.gasUsed}
+								</TableCell>
+								<TableCell className='text-muted-foreground'>
+									{event.executionTime}
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			</div>
+		</div>
+	);
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
Closes #20 

This PR adds a "Recent Events" table to the Overview page, displaying the last 5 events with their status, gas usage, and execution time. The component includes loading states and follows the shadcn New York theme.

Changes:
- Create RecentEvents component with sample data
- Add RecentEventsSkeleton for loading states
- Style status badges to match Activity page
- Add "View All" link to Activity page

Testing:
- [x] Verify loading skeleton displays correctly
- [x] Check status badges show correct colors
- [x] Confirm "View All" link navigates to Activity page
- [x] Test responsive layout on mobile devices