### PR TITLE
feat: split Performance page into Gas Usage and Execution Time tabs

### DIFF
--- a/app/dashboard/performance/page.tsx
+++ b/app/dashboard/performance/page.tsx
@@ -6,24 +6,40 @@ import { ContractCallsChart } from '@/components/charts/contract-calls-chart';
 import { ResourceUsageChart } from '@/components/charts/resource-usage-chart';
 import { ResponseTimeChart } from '@/components/charts/response-time-chart';
 import { SuccessRateChart } from '@/components/charts/success-rate-chart';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function PerformancePage() {
 	return (
 		<div className='flex flex-1 flex-col p-4'>
-			<div className='grid gap-4 sm:grid-cols-2'>
-				<Suspense fallback={<ChartSkeleton />}>
-					<ContractCallsChart />
-				</Suspense>
-				<Suspense fallback={<ChartSkeleton />}>
-					<SuccessRateChart />
-				</Suspense>
-				<Suspense fallback={<ChartSkeleton />}>
-					<ResponseTimeChart />
-				</Suspense>
-				<Suspense fallback={<ChartSkeleton />}>
-					<ResourceUsageChart />
-				</Suspense>
-			</div>
+			<Tabs
+				defaultValue='gas'
+				className='w-full'
+			>
+				<TabsList className='mb-4'>
+					<TabsTrigger value='gas'>Gas Usage</TabsTrigger>
+					<TabsTrigger value='execution'>Execution Time</TabsTrigger>
+				</TabsList>
+				<TabsContent value='gas'>
+					<div className='grid gap-4 sm:grid-cols-2'>
+						<Suspense fallback={<ChartSkeleton />}>
+							<ContractCallsChart />
+						</Suspense>
+						<Suspense fallback={<ChartSkeleton />}>
+							<SuccessRateChart />
+						</Suspense>
+					</div>
+				</TabsContent>
+				<TabsContent value='execution'>
+					<div className='grid gap-4 sm:grid-cols-2'>
+						<Suspense fallback={<ChartSkeleton />}>
+							<ResponseTimeChart />
+						</Suspense>
+						<Suspense fallback={<ChartSkeleton />}>
+							<ResourceUsageChart />
+						</Suspense>
+					</div>
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"@radix-ui/react-select": "^2.1.4",
 		"@radix-ui/react-separator": "^1.1.1",
 		"@radix-ui/react-slot": "^1.1.1",
+		"@radix-ui/react-tabs": "^1.1.2",
 		"@radix-ui/react-toggle": "^1.1.1",
 		"@radix-ui/react-toggle-group": "^1.1.1",
 		"@radix-ui/react-tooltip": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   '@radix-ui/react-slot':
     specifier: ^1.1.1
     version: 1.1.1(@types/react@18.3.18)(react@18.3.1)
+  '@radix-ui/react-tabs':
+    specifier: ^1.1.2
+    version: 1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
   '@radix-ui/react-toggle':
     specifier: ^1.1.1
     version: 1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
@@ -1224,6 +1227,33 @@ packages:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
       '@types/react': 18.3.18
       react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-tabs@1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-9u/tQJMcC2aGq7KXpGivMm1mgq7oRJKXphDwdypPd/j21j/2znamPU8WkXgnhUaTrSFNIt8XhOyCAupg8/GbwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-toggle-group@1.1.1(@types/react-dom@18.3.5)(@types/react@18.3.18)(react-dom@18.3.1)(react@18.3.1):


### PR DESCRIPTION
Closes #26

This PR splits the Performance page into two focused tabs: Gas Usage and Execution Time. Each tab contains relevant charts for better organization and clarity.

### Changes:
- Added shadcn Tabs component for navigation
- Created two main tabs:
  - Gas Usage: Contract Calls and Success Rate charts
  - Execution Time: Response Time and Resource Usage charts
- Maintained responsive grid layout within each tab
- Preserved loading states with Suspense boundaries

### Features:
- 📑 Tabbed navigation for focused views
- 📊 Logically grouped performance charts
- 🎨 Consistent styling with New York theme
- 📱 Responsive layout in all views

### Testing:
[x] Verified tab navigation works correctly
[x] Confirmed all charts render in appropriate tabs
[x] Tested loading states with Suspense
[x] Checked mobile responsiveness
[x] Validated chart interactions in both tabs
[x] Ensured consistent styling across tabs