### PR TITLE
feat: add Top Calls drill-down for Performance charts

### DIFF
--- a/components/charts/contract-calls-chart.tsx
+++ b/components/charts/contract-calls-chart.tsx
@@ -16,7 +16,6 @@ import {
 	commonAxisConfig,
 	commonGridConfig,
 	formatDate,
-	useTimeRange,
 	ChartCard,
 	groupDataByDate,
 	filterDataByTimeRange,

--- a/components/charts/contract-calls-chart.tsx
+++ b/components/charts/contract-calls-chart.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 import { TrendingUp } from 'lucide-react';
+import { subDays } from 'date-fns';
 
 import {
 	ChartConfig,
@@ -17,17 +18,31 @@ import {
 	formatDate,
 	useTimeRange,
 	ChartCard,
+	groupDataByDate,
+	filterDataByTimeRange,
+	TimeRange,
 } from './chart-utils';
+import { Button } from '@/components/ui/button';
+import { TopCallsDialog } from '@/components/performance/top-calls-dialog';
+
+interface ContractCall {
+	id: string;
+	timestamp: string;
+	functionName: string;
+	gasUsed: number;
+	transactionId: string;
+	success: boolean;
+}
 
 // Sample data - we'll replace this with real contract calls data later
-const chartData = [
-	{ date: '2024-12-01', total: 234, success: 200, failed: 34 },
-	{ date: '2024-12-02', total: 278, success: 240, failed: 38 },
-	{ date: '2024-12-03', total: 189, success: 170, failed: 19 },
-	{ date: '2024-12-04', total: 289, success: 250, failed: 39 },
-	{ date: '2024-12-05', total: 349, success: 300, failed: 49 },
-	{ date: '2024-12-06', total: 289, success: 250, failed: 39 },
-];
+const sampleData: ContractCall[] = Array.from({ length: 30 }, (_, i) => ({
+	id: `call-${i}`,
+	timestamp: subDays(new Date(), i).toISOString(),
+	functionName: `transfer${i % 2 === 0 ? 'From' : 'To'}`,
+	gasUsed: Math.floor(Math.random() * 5000000) + 1000000,
+	transactionId: `0x${Math.random().toString(16).slice(2)}`,
+	success: Math.random() > 0.1,
+}));
 
 const chartConfig = {
 	total: {
@@ -45,11 +60,35 @@ const chartConfig = {
 } satisfies ChartConfig;
 
 export function ContractCallsChart() {
-	const { timeRange, setTimeRange, filterDataByTimeRange } = useTimeRange();
-	const filteredData = filterDataByTimeRange(chartData);
+	const [timeRange, setTimeRange] = React.useState<TimeRange>('7d');
+	const [showTopCalls, setShowTopCalls] = React.useState(false);
 
-	const totalCalls = filteredData.reduce((acc, curr) => acc + curr.total, 0);
-	const averageCalls = Math.round(totalCalls / filteredData.length);
+	// Group data by date and calculate totals
+	const chartData = React.useMemo(() => {
+		const filtered = filterDataByTimeRange(sampleData, timeRange);
+		return groupDataByDate(filtered, (calls) => ({
+			total: calls.length,
+			success: calls.filter((call) => call.success).length,
+			failed: calls.filter((call) => !call.success).length,
+		}));
+	}, [timeRange]);
+
+	// Get top calls by gas usage
+	const topCalls = React.useMemo(() => {
+		return sampleData
+			.sort((a, b) => b.gasUsed - a.gasUsed)
+			.slice(0, 20)
+			.map((call) => ({
+				id: call.id,
+				timestamp: new Date(call.timestamp),
+				function: call.functionName,
+				value: call.gasUsed,
+				transactionId: call.transactionId,
+			}));
+	}, []);
+
+	const totalCalls = chartData.reduce((acc, curr) => acc + curr.total, 0);
+	const averageCalls = Math.round(totalCalls / chartData.length);
 
 	return (
 		<ChartCard
@@ -68,13 +107,22 @@ export function ContractCallsChart() {
 					</div>
 				</div>
 			}
+			action={
+				<Button
+					variant='outline'
+					size='sm'
+					onClick={() => setShowTopCalls(true)}
+				>
+					View Top Calls
+				</Button>
+			}
 		>
 			<ChartContainer
 				config={chartConfig}
 				className={chartContainerClass}
 			>
 				<AreaChart
-					data={filteredData}
+					data={chartData}
 					margin={{
 						left: 12,
 						right: 12,
@@ -127,6 +175,12 @@ export function ContractCallsChart() {
 					/>
 				</AreaChart>
 			</ChartContainer>
+			<TopCallsDialog
+				open={showTopCalls}
+				onOpenChange={setShowTopCalls}
+				type='gas'
+				data={topCalls}
+			/>
 		</ChartCard>
 	);
 }

--- a/components/charts/mini-gas-chart.tsx
+++ b/components/charts/mini-gas-chart.tsx
@@ -251,7 +251,7 @@ export function MiniGasChart() {
 							}}
 							dot={({ cx, cy, payload }) => {
 								if (!payload || payload.gasUsage <= threshold)
-									return null;
+									return <g />;
 								return (
 									<circle
 										cx={cx}

--- a/components/charts/response-time-chart.tsx
+++ b/components/charts/response-time-chart.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import * as React from 'react';
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+import {
+	Area,
+	AreaChart,
+	CartesianGrid,
+	XAxis,
+	YAxis,
+	ResponsiveContainer,
+} from 'recharts';
 import { format, subDays } from 'date-fns';
 import { Button } from '@/components/ui/button';
 import { TopCallsDialog } from '@/components/performance/top-calls-dialog';
@@ -93,68 +100,71 @@ export function ResponseTimeChart() {
 			}
 		>
 			<div className='h-[350px] w-full'>
-				<AreaChart
-					data={chartData}
-					margin={{
-						left: 12,
-						right: 12,
-						top: 12,
-						bottom: 12,
-					}}
-					width={800}
-					height={350}
+				<ResponsiveContainer
+					width='100%'
+					height='100%'
 				>
-					<defs>
-						<linearGradient
-							id='responseTimeGradient'
-							x1='0'
-							y1='0'
-							x2='0'
-							y2='1'
-						>
-							<stop
-								offset='5%'
-								stopColor='hsl(var(--primary))'
-								stopOpacity={0.2}
-							/>
-							<stop
-								offset='95%'
-								stopColor='hsl(var(--primary))'
-								stopOpacity={0}
-							/>
-						</linearGradient>
-					</defs>
-					<CartesianGrid
-						strokeDasharray='3 3'
-						className='stroke-muted'
-					/>
-					<XAxis
-						dataKey='date'
-						tickFormatter={(date) =>
-							format(new Date(date), 'MMM d')
-						}
-						className='text-xs'
-					/>
-					<YAxis
-						tickFormatter={(value) => `${value.toFixed(2)}s`}
-						className='text-xs'
-					/>
-					<Area
-						type='monotone'
-						dataKey='average'
-						stroke='hsl(var(--primary))'
-						fill='url(#responseTimeGradient)'
-						strokeWidth={2}
-					/>
-					<Area
-						type='monotone'
-						dataKey='p95'
-						stroke='hsl(var(--destructive))'
-						fill='none'
-						strokeWidth={2}
-						strokeDasharray='3 3'
-					/>
-				</AreaChart>
+					<AreaChart
+						data={chartData}
+						margin={{
+							left: 12,
+							right: 12,
+							top: 12,
+							bottom: 12,
+						}}
+					>
+						<defs>
+							<linearGradient
+								id='responseTimeGradient'
+								x1='0'
+								y1='0'
+								x2='0'
+								y2='1'
+							>
+								<stop
+									offset='5%'
+									stopColor='hsl(var(--primary))'
+									stopOpacity={0.2}
+								/>
+								<stop
+									offset='95%'
+									stopColor='hsl(var(--primary))'
+									stopOpacity={0}
+								/>
+							</linearGradient>
+						</defs>
+						<CartesianGrid
+							strokeDasharray='3 3'
+							className='stroke-muted'
+						/>
+						<XAxis
+							dataKey='date'
+							tickFormatter={(date) =>
+								format(new Date(date), 'MMM d')
+							}
+							className='text-xs'
+						/>
+						<YAxis
+							tickFormatter={(value) => `${value.toFixed(2)}s`}
+							className='text-xs'
+						/>
+						<Area
+							type='monotone'
+							dataKey='average'
+							stroke='hsl(var(--primary))'
+							fill='url(#responseTimeGradient)'
+							strokeWidth={2}
+						/>
+						<Area
+							type='monotone'
+							dataKey='p95'
+							stroke='hsl(var(--destructive))'
+							fill='none'
+							strokeWidth={2}
+							strokeDasharray='3 3'
+						/>
+					</AreaChart>
+				</ResponsiveContainer>
 			</div>
 			<TopCallsDialog
 				open={showTopCalls}

--- a/components/performance/top-calls-dialog.tsx
+++ b/components/performance/top-calls-dialog.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import * as React from 'react';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { format } from 'date-fns';
+
+interface TopCall {
+	id: string;
+	timestamp: Date;
+	function: string;
+	value: number; // gas usage or execution time
+	transactionId: string;
+}
+
+interface TopCallsDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	type: 'gas' | 'execution';
+	data: TopCall[];
+}
+
+export function TopCallsDialog({
+	open,
+	onOpenChange,
+	type,
+	data,
+}: TopCallsDialogProps) {
+	const [page, setPage] = React.useState(1);
+	const itemsPerPage = 5;
+	const totalPages = Math.ceil(data.length / itemsPerPage);
+
+	const paginatedData = data.slice(
+		(page - 1) * itemsPerPage,
+		page * itemsPerPage
+	);
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={onOpenChange}
+		>
+			<DialogContent className='max-w-3xl'>
+				<DialogHeader>
+					<DialogTitle>
+						Top Calls by{' '}
+						{type === 'gas' ? 'Gas Usage' : 'Execution Time'}
+					</DialogTitle>
+					<DialogDescription>
+						{type === 'gas'
+							? 'Contract calls that consumed the most gas'
+							: 'Contract calls that took the longest to execute'}
+					</DialogDescription>
+				</DialogHeader>
+				<div className='relative'>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Timestamp</TableHead>
+								<TableHead>Function</TableHead>
+								<TableHead>
+									{type === 'gas'
+										? 'Gas Used'
+										: 'Execution Time'}
+								</TableHead>
+								<TableHead>Transaction ID</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{paginatedData.map((call) => (
+								<TableRow key={call.id}>
+									<TableCell>
+										{format(call.timestamp, 'PPp')}
+									</TableCell>
+									<TableCell className='font-mono'>
+										{call.function}
+									</TableCell>
+									<TableCell>
+										{type === 'gas'
+											? `${(call.value / 1000000).toFixed(
+													2
+											  )}M`
+											: `${call.value.toFixed(2)}s`}
+									</TableCell>
+									<TableCell className='font-mono'>
+										{call.transactionId}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+					{totalPages > 1 && (
+						<div className='flex items-center justify-end space-x-2 py-4'>
+							<Button
+								variant='outline'
+								size='sm'
+								onClick={() => setPage(page - 1)}
+								disabled={page === 1}
+							>
+								Previous
+							</Button>
+							<Button
+								variant='outline'
+								size='sm'
+								onClick={() => setPage(page + 1)}
+								disabled={page === totalPages}
+							>
+								Next
+							</Button>
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
Closes #28

This PR adds a drill-down feature to the Performance page charts, allowing users to view detailed information about top gas usage and execution time calls.

### Changes:
- Added "View Top Calls" button to Gas Usage and Execution Time charts
- Created TopCallsDialog component with:
  - Paginated table showing top 20 calls
  - Formatted timestamps and values
  - Clear labels and descriptions
- Made Response Time chart responsive
- Fixed chart dot type errors

### Features:
- 📊 Top calls by gas usage and execution time
- 📑 Paginated table with 5 items per page
- 🎨 Consistent shadcn/New York styling
- 📱 Responsive layout and charts
- 🔍 Detailed information on hover

### Testing:
[x] Verified top calls sorting works correctly
[x] Tested pagination functionality
[x] Confirmed responsive behavior
[x] Checked value formatting (gas in M, time in s)
[x] Validated dialog open/close behavior
[x] Ensured consistent styling across components