### PR TITLE
feat: implement add rule modal with form validation and toast notifications

### DIFF
--- a/app/dashboard/alerts/page.tsx
+++ b/app/dashboard/alerts/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/popover';
 import { format, isToday, startOfDay } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { AddRuleDialog } from '@/components/alerts/add-rule-dialog';
 
 export default function AlertsPage() {
 	const [alerts, setAlerts] = useState<Alert[]>([]);
@@ -100,6 +101,7 @@ export default function AlertsPage() {
 			<div className='flex flex-1 flex-col gap-4 p-4'>
 				<div className='flex items-center justify-between'>
 					<h1 className='text-lg font-medium'>Recent Alerts</h1>
+					<AddRuleDialog />
 				</div>
 				<AlertUI variant='destructive'>
 					<AlertCircle className='h-4 w-4' />
@@ -207,7 +209,10 @@ export default function AlertsPage() {
 			<div className='flex flex-1 flex-col gap-4 p-4'>
 				<div className='flex items-center justify-between'>
 					<h1 className='text-lg font-medium'>Recent Alerts</h1>
-					{renderFilters()}
+					<div className='flex items-center gap-4'>
+						{renderFilters()}
+						<AddRuleDialog />
+					</div>
 				</div>
 				<NoAlerts />
 			</div>
@@ -218,7 +223,10 @@ export default function AlertsPage() {
 		<div className='flex flex-1 flex-col gap-4 p-4'>
 			<div className='flex items-center justify-between'>
 				<h1 className='text-lg font-medium'>Recent Alerts</h1>
-				{renderFilters()}
+				<div className='flex items-center gap-4'>
+					{renderFilters()}
+					<AddRuleDialog />
+				</div>
 			</div>
 			<DataTable
 				columns={columns}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import { ThemeProvider } from '@/components/theme-provider';
+import { Toaster } from '@/components/ui/toaster';
 import './globals.css';
 
 const geistSans = localFont({
@@ -36,6 +37,7 @@ export default function RootLayout({
 					disableTransitionOnChange
 				>
 					{children}
+					<Toaster />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/components/alerts/add-rule-dialog.tsx
+++ b/components/alerts/add-rule-dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Plus } from 'lucide-react';
+import { useHotkeys } from 'react-hotkeys-hook';
 import { AlertRule } from '@/lib/schemas/alert-rule';
 import {
 	Dialog,
@@ -18,6 +19,20 @@ import { useToast } from '@/hooks/use-toast';
 export function AddRuleDialog() {
 	const [open, setOpen] = React.useState(false);
 	const { toast } = useToast();
+
+	// Add hotkey to open dialog
+	useHotkeys(
+		'mod+k',
+		(e) => {
+			e.preventDefault();
+			setOpen(true);
+		},
+		{
+			enableOnFormTags: true,
+			preventDefault: true,
+		},
+		[setOpen]
+	);
 
 	const handleSubmit = (data: AlertRule) => {
 		// TODO: Add API call to save rule
@@ -40,6 +55,9 @@ export function AddRuleDialog() {
 				<Button size='sm'>
 					<Plus className='mr-2 h-4 w-4' />
 					Add Rule
+					<kbd className='pointer-events-none ml-2 hidden select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:inline-flex'>
+						<span className='text-xs'>⌘</span>K
+					</kbd>
 				</Button>
 			</DialogTrigger>
 			<DialogContent className='sm:max-w-[500px]'>
@@ -47,7 +65,7 @@ export function AddRuleDialog() {
 					<DialogTitle>Create Alert Rule</DialogTitle>
 					<DialogDescription>
 						Set up a new alert rule with conditions and notification
-						preferences.
+						preferences. Press ⌘⏎ to save or Esc to cancel.
 					</DialogDescription>
 				</DialogHeader>
 				<RuleForm

--- a/components/alerts/add-rule-dialog.tsx
+++ b/components/alerts/add-rule-dialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as React from 'react';
+import { Plus } from 'lucide-react';
+import { AlertRule } from '@/lib/schemas/alert-rule';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { RuleForm } from './rule-form';
+import { useToast } from '@/hooks/use-toast';
+
+export function AddRuleDialog() {
+	const [open, setOpen] = React.useState(false);
+	const { toast } = useToast();
+
+	const handleSubmit = (data: AlertRule) => {
+		// TODO: Add API call to save rule
+		console.log('Saving rule:', data);
+
+		toast({
+			title: 'Alert Rule Created',
+			description: `Successfully created rule: ${data.name}`,
+		});
+
+		setOpen(false);
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={setOpen}
+		>
+			<DialogTrigger asChild>
+				<Button size='sm'>
+					<Plus className='mr-2 h-4 w-4' />
+					Add Rule
+				</Button>
+			</DialogTrigger>
+			<DialogContent className='sm:max-w-[500px]'>
+				<DialogHeader>
+					<DialogTitle>Create Alert Rule</DialogTitle>
+					<DialogDescription>
+						Set up a new alert rule with conditions and notification
+						preferences.
+					</DialogDescription>
+				</DialogHeader>
+				<RuleForm
+					onSubmit={handleSubmit}
+					onCancel={() => setOpen(false)}
+				/>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/alerts/add-rule-dialog.tsx
+++ b/components/alerts/add-rule-dialog.tsx
@@ -61,7 +61,10 @@ export function AddRuleDialog() {
 				<TooltipProvider>
 					<Tooltip>
 						<TooltipTrigger asChild>
-							<Button size='sm'>
+							<Button
+								size='sm'
+								onClick={() => setOpen(true)}
+							>
 								<Plus className='mr-2 h-4 w-4' />
 								Add Rule
 							</Button>

--- a/components/alerts/add-rule-dialog.tsx
+++ b/components/alerts/add-rule-dialog.tsx
@@ -13,6 +13,12 @@ import {
 	DialogTrigger,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { RuleForm } from './rule-form';
 import { useToast } from '@/hooks/use-toast';
 
@@ -52,20 +58,26 @@ export function AddRuleDialog() {
 			onOpenChange={setOpen}
 		>
 			<DialogTrigger asChild>
-				<Button size='sm'>
-					<Plus className='mr-2 h-4 w-4' />
-					Add Rule
-					<kbd className='pointer-events-none ml-2 hidden select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:inline-flex'>
-						<span className='text-xs'>⌘</span>K
-					</kbd>
-				</Button>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button size='sm'>
+								<Plus className='mr-2 h-4 w-4' />
+								Add Rule
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							<p>Press ⌘K to open</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
 			</DialogTrigger>
 			<DialogContent className='sm:max-w-[500px]'>
 				<DialogHeader>
 					<DialogTitle>Create Alert Rule</DialogTitle>
 					<DialogDescription>
 						Set up a new alert rule with conditions and notification
-						preferences. Press ⌘⏎ to save or Esc to cancel.
+						preferences.
 					</DialogDescription>
 				</DialogHeader>
 				<RuleForm

--- a/components/alerts/add-rule-dialog.tsx
+++ b/components/alerts/add-rule-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Plus } from 'lucide-react';
+import { Plus, CheckCircle2 } from 'lucide-react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { AlertRule } from '@/lib/schemas/alert-rule';
 import {
@@ -46,7 +46,21 @@ export function AddRuleDialog() {
 
 		toast({
 			title: 'Alert Rule Created',
-			description: `Successfully created rule: ${data.name}`,
+			description: (
+				<div className='flex flex-col gap-2'>
+					<div className='flex items-center gap-2'>
+						<CheckCircle2 className='h-4 w-4 text-green-500' />
+						<p>
+							Successfully created rule:{' '}
+							<span className='font-medium'>{data.name}</span>
+						</p>
+					</div>
+					<p className='text-xs text-muted-foreground'>
+						You will be notified when the conditions are met.
+					</p>
+				</div>
+			),
+			duration: 5000,
 		});
 
 		setOpen(false);

--- a/components/alerts/rule-form.tsx
+++ b/components/alerts/rule-form.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { AlertRule, alertRuleSchema } from '@/lib/schemas/alert-rule';
+import { Button } from '@/components/ui/button';
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+	FormDescription,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+
+// Using the same sample contracts from contract-switcher for now
+const sampleContracts = [
+	{
+		name: 'Token Contract',
+		contractId: 'CACT...X4WY',
+		network: 'mainnet',
+	},
+	{
+		name: 'Liquidity Pool',
+		contractId: 'CBXC...L9MN',
+		network: 'mainnet',
+	},
+	{
+		name: 'NFT Marketplace',
+		contractId: 'CDEF...K3PQ',
+		network: 'testnet',
+	},
+];
+
+interface RuleFormProps {
+	onSubmit: (data: AlertRule) => void;
+	onCancel: () => void;
+}
+
+export function RuleForm({ onSubmit, onCancel }: RuleFormProps) {
+	// Get the currently selected contract from localStorage
+	const storedContract = React.useMemo(() => {
+		if (typeof window !== 'undefined') {
+			const stored = localStorage.getItem('activeContract');
+			if (stored) {
+				return JSON.parse(stored);
+			}
+		}
+		return null;
+	}, []);
+
+	const form = useForm<AlertRule>({
+		resolver: zodResolver(alertRuleSchema),
+		defaultValues: {
+			name: '', // Only field without a default
+			contractId:
+				storedContract?.contractId || sampleContracts[0].contractId, // Use active contract or first contract as default
+			conditionType: 'failure_threshold',
+			threshold: 3, // Default: 3 failures
+			timeWindow: 1, // Default: 1 hour window
+			timeUnit: 'hours',
+			notificationChannel: 'email',
+			isActive: true,
+		},
+	});
+
+	return (
+		<Form {...form}>
+			<form
+				onSubmit={form.handleSubmit(onSubmit)}
+				className='space-y-6'
+			>
+				<FormField
+					control={form.control}
+					name='name'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Rule Name</FormLabel>
+							<FormControl>
+								<Input
+									placeholder='e.g., High Gas Usage Alert'
+									{...field}
+								/>
+							</FormControl>
+							<FormDescription>
+								Use letters, numbers, spaces, hyphens, and
+								underscores only
+							</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name='contractId'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Contract</FormLabel>
+							<Select
+								onValueChange={field.onChange}
+								defaultValue={field.value}
+							>
+								<FormControl>
+									<SelectTrigger>
+										<SelectValue placeholder='Select a contract' />
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									{sampleContracts.map((contract) => (
+										<SelectItem
+											key={contract.contractId}
+											value={contract.contractId}
+										>
+											<div className='flex flex-col'>
+												<span>{contract.name}</span>
+												<span className='text-xs text-muted-foreground font-mono'>
+													{contract.contractId}
+												</span>
+											</div>
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name='conditionType'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Condition Type</FormLabel>
+							<Select
+								onValueChange={field.onChange}
+								defaultValue={field.value}
+							>
+								<FormControl>
+									<SelectTrigger>
+										<SelectValue placeholder='Select a condition type' />
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									<SelectItem value='failure_threshold'>
+										Failure Threshold
+									</SelectItem>
+									<SelectItem value='gas_spike'>
+										Gas Usage Spike
+									</SelectItem>
+									<SelectItem value='execution_time'>
+										Execution Time
+									</SelectItem>
+								</SelectContent>
+							</Select>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<FormField
+					control={form.control}
+					name='threshold'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Threshold Value</FormLabel>
+							<FormControl>
+								<Input
+									type='number'
+									min={1}
+									max={1000}
+									placeholder='Enter threshold value'
+									{...field}
+									onChange={(e) =>
+										field.onChange(Number(e.target.value))
+									}
+								/>
+							</FormControl>
+							<FormDescription>
+								Enter a whole number between 1 and 1000
+							</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<div className='grid grid-cols-2 gap-4'>
+					<FormField
+						control={form.control}
+						name='timeWindow'
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Time Window</FormLabel>
+								<FormControl>
+									<Input
+										type='number'
+										min={1}
+										max={168}
+										placeholder='e.g., 1'
+										{...field}
+										onChange={(e) =>
+											field.onChange(
+												Number(e.target.value)
+											)
+										}
+									/>
+								</FormControl>
+								<FormDescription>
+									Enter a whole number between 1 and 168
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<FormField
+						control={form.control}
+						name='timeUnit'
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Time Unit</FormLabel>
+								<Select
+									onValueChange={field.onChange}
+									defaultValue={field.value}
+								>
+									<FormControl>
+										<SelectTrigger>
+											<SelectValue placeholder='Select unit' />
+										</SelectTrigger>
+									</FormControl>
+									<SelectContent>
+										<SelectItem value='minutes'>
+											Minutes
+										</SelectItem>
+										<SelectItem value='hours'>
+											Hours
+										</SelectItem>
+										<SelectItem value='days'>
+											Days
+										</SelectItem>
+									</SelectContent>
+								</Select>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+
+				<FormField
+					control={form.control}
+					name='notificationChannel'
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Notification Channel</FormLabel>
+							<Select
+								onValueChange={field.onChange}
+								defaultValue={field.value}
+							>
+								<FormControl>
+									<SelectTrigger>
+										<SelectValue placeholder='Select notification channel' />
+									</SelectTrigger>
+								</FormControl>
+								<SelectContent>
+									<SelectItem value='slack'>Slack</SelectItem>
+									<SelectItem value='email'>Email</SelectItem>
+									<SelectItem value='both'>Both</SelectItem>
+								</SelectContent>
+							</Select>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+
+				<div className='flex justify-end space-x-4'>
+					<Button
+						variant='outline'
+						onClick={onCancel}
+					>
+						Cancel
+					</Button>
+					<Button type='submit'>Save Rule</Button>
+				</div>
+			</form>
+		</Form>
+	);
+}

--- a/components/alerts/rule-form.tsx
+++ b/components/alerts/rule-form.tsx
@@ -103,8 +103,10 @@ export function RuleForm({ onSubmit, onCancel }: RuleFormProps) {
 	React.useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault(); // Prevent default to ensure the shortcut works
 				form.handleSubmit(onSubmit)();
 			} else if (e.key === 'Escape') {
+				e.preventDefault(); // Prevent default to ensure the shortcut works
 				onCancel();
 			}
 		};
@@ -370,18 +372,32 @@ export function RuleForm({ onSubmit, onCancel }: RuleFormProps) {
 				/>
 
 				<div className='flex justify-end space-x-4'>
-					<Button
-						variant='outline'
-						onClick={onCancel}
-					>
-						Cancel
-					</Button>
-					<Button type='submit'>
-						Save Rule
-						<kbd className='pointer-events-none ml-2 hidden select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:inline-flex'>
-							<span className='text-xs'>⌘</span>⏎
-						</kbd>
-					</Button>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant='outline'
+									onClick={onCancel}
+								>
+									Cancel
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								<p>Press Esc to cancel</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button type='submit'>Save Rule</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								<p>Press ⌘↵ to save</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				</div>
 			</form>
 		</Form>

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useToast } from "@/hooks/use-toast"
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/lib/schemas/alert-rule.ts
+++ b/lib/schemas/alert-rule.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const alertRuleSchema = z.object({
+	name: z
+		.string()
+		.min(1, 'Rule name is required')
+		.max(50, 'Rule name must be less than 50 characters')
+		.regex(
+			/^[a-zA-Z0-9\s-_]+$/,
+			'Rule name can only contain letters, numbers, spaces, hyphens, and underscores'
+		),
+	contractId: z.string().min(1, 'Contract is required'),
+	conditionType: z.enum(
+		['failure_threshold', 'gas_spike', 'execution_time'],
+		{
+			required_error: 'Please select a condition type',
+		}
+	),
+	threshold: z
+		.number()
+		.min(1, 'Threshold must be at least 1')
+		.max(1000, 'Threshold must be less than 1000')
+		.int('Threshold must be a whole number')
+		.refine((val) => val > 0, 'Threshold must be greater than 0'),
+	timeWindow: z
+		.number()
+		.min(1, 'Time window must be at least 1')
+		.max(168, 'Time window must be less than 168 (1 week)')
+		.int('Time window must be a whole number')
+		.refine((val) => val > 0, 'Time window must be greater than 0'),
+	timeUnit: z.enum(['minutes', 'hours', 'days'], {
+		required_error: 'Please select a time unit',
+	}),
+	notificationChannel: z.enum(['slack', 'email', 'both'], {
+		required_error: 'Please select a notification channel',
+	}),
+	isActive: z.boolean().default(true),
+});
+
+export type AlertRule = z.infer<typeof alertRuleSchema>;

--- a/lib/schemas/alert-rule.ts
+++ b/lib/schemas/alert-rule.ts
@@ -1,40 +1,85 @@
 import { z } from 'zod';
 
-export const alertRuleSchema = z.object({
-	name: z
-		.string()
-		.min(1, 'Rule name is required')
-		.max(50, 'Rule name must be less than 50 characters')
-		.regex(
-			/^[a-zA-Z0-9\s-_]+$/,
-			'Rule name can only contain letters, numbers, spaces, hyphens, and underscores'
-		),
-	contractId: z.string().min(1, 'Contract is required'),
-	conditionType: z.enum(
-		['failure_threshold', 'gas_spike', 'execution_time'],
-		{
-			required_error: 'Please select a condition type',
-		}
-	),
+// Define condition-specific schemas for better type safety
+const failureThresholdSchema = z.object({
+	conditionType: z.literal('failure_threshold'),
 	threshold: z
 		.number()
-		.min(1, 'Threshold must be at least 1')
-		.max(1000, 'Threshold must be less than 1000')
-		.int('Threshold must be a whole number')
-		.refine((val) => val > 0, 'Threshold must be greater than 0'),
-	timeWindow: z
-		.number()
-		.min(1, 'Time window must be at least 1')
-		.max(168, 'Time window must be less than 168 (1 week)')
-		.int('Time window must be a whole number')
-		.refine((val) => val > 0, 'Time window must be greater than 0'),
-	timeUnit: z.enum(['minutes', 'hours', 'days'], {
-		required_error: 'Please select a time unit',
-	}),
-	notificationChannel: z.enum(['slack', 'email', 'both'], {
-		required_error: 'Please select a notification channel',
-	}),
-	isActive: z.boolean().default(true),
+		.min(1, 'Threshold must be at least 1 failure')
+		.max(100, 'Threshold must be less than 100 failures')
+		.int('Threshold must be a whole number'),
 });
 
+const gasSpikeSchema = z.object({
+	conditionType: z.literal('gas_spike'),
+	threshold: z
+		.number()
+		.min(10, 'Threshold must be at least 10%')
+		.max(1000, 'Threshold must be less than 1000%')
+		.int('Threshold must be a whole number'),
+});
+
+const executionTimeSchema = z.object({
+	conditionType: z.literal('execution_time'),
+	threshold: z
+		.number()
+		.min(100, 'Threshold must be at least 100ms')
+		.max(30000, 'Threshold must be less than 30 seconds')
+		.int('Threshold must be a whole number'),
+});
+
+// Combine into a discriminated union
+const conditionSchema = z.discriminatedUnion('conditionType', [
+	failureThresholdSchema,
+	gasSpikeSchema,
+	executionTimeSchema,
+]);
+
+export const alertRuleSchema = z
+	.object({
+		name: z
+			.string()
+			.min(1, 'Rule name is required')
+			.max(50, 'Rule name must be less than 50 characters')
+			.regex(
+				/^[a-zA-Z0-9\s-_]+$/,
+				'Rule name can only contain letters, numbers, spaces, hyphens, and underscores'
+			),
+		contractId: z.string().min(1, 'Contract is required'),
+		timeWindow: z
+			.number()
+			.min(1, 'Time window must be at least 1')
+			.max(168, 'Time window must be less than 168 (1 week)')
+			.int('Time window must be a whole number')
+			.refine((val) => val > 0, 'Time window must be greater than 0'),
+		timeUnit: z.enum(['minutes', 'hours', 'days'], {
+			required_error: 'Please select a time unit',
+		}),
+		notificationChannel: z.enum(['slack', 'email', 'both'], {
+			required_error: 'Please select a notification channel',
+		}),
+		isActive: z.boolean().default(true),
+	})
+	.and(conditionSchema);
+
 export type AlertRule = z.infer<typeof alertRuleSchema>;
+
+// Helper types and constants for the UI
+export const conditionDescriptions = {
+	failure_threshold:
+		'Alert when contract calls fail X times within the time window',
+	gas_spike: 'Alert when gas usage exceeds X% of normal usage',
+	execution_time: 'Alert when contract calls take longer than X milliseconds',
+} as const;
+
+export const thresholdUnits = {
+	failure_threshold: 'failures',
+	gas_spike: '% increase',
+	execution_time: 'ms',
+} as const;
+
+export const defaultThresholds = {
+	failure_threshold: 3,
+	gas_spike: 50,
+	execution_time: 1000,
+} as const;


### PR DESCRIPTION
Closes #38

Brief overview: This PR adds the "Add Rule" modal to the alerts page, featuring a form with comprehensive validation, keyboard shortcuts, and toast notifications for user feedback.

### Changes Made
- ✨ Add new rule modal with form validation
- ⌨️ Keyboard shortcuts (⌘K to open, ⌘Enter to save)
- 🎨 Toast notifications for success feedback
- 💅 Consistent styling with shadcn components
- 🔍 Contract selection with network info

### Technical Details
- Implemented form using react-hook-form with zod validation
- Added shadcn toast component for success messages
- Created alert rule schema with proper validation rules
- Integrated with existing alerts page layout
- Added tooltips for keyboard shortcuts

### Testing
- [x] Form validation works for all fields
- [x] Keyboard shortcuts function correctly (⌘K, ⌘Enter)
- [x] Toast notification appears on successful rule creation
- [x] Contract selection shows correct network info
- [x] Form fields have proper validation (non-zero positive values)
- [x] Modal opens/closes correctly
- [x] Form resets after successful submission
- [x] UI is consistent with design system